### PR TITLE
style.css: fix the phone number overlapping `contactbtn`

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -326,7 +326,6 @@ main {
   border: none;
   border-radius: 10px;
   padding: 10px;
-  width: 100px;
   margin: 4px 5px;
   cursor: pointer;
   transition: 0.3s ease-in-out;


### PR DESCRIPTION
Hi Ellie! :smile:  First pull-request ever here.

I just randomly decided to open your website and seen this bug, so I tried to track it down :D

IIRC, it would be possible to keep them 100px wide, but would have to tell the content to shrink down and get on the next line (with `flex-wrap`?). That wouldn't look good though.

Other option would be to set higher width for both buttons, or set them individually, but in my opinion, they look better when they're auto-adjusted based on the text content.

Now I'd add a little more padding to the left-right at line 328: `padding: 10px 15px`, but I didn't want to include it here.

Hope it helps! :)


Before:
![image](https://github.com/elliezub/Designer-Website/assets/130125082/e5e44493-a656-4c94-bfd0-c724409c13fd)

After:
![image](https://github.com/elliezub/Designer-Website/assets/130125082/6ef87c83-4409-43fe-83d4-e1a3f0383d9b)
